### PR TITLE
add SCSS variable docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,15 @@ let loader = this.$loading.show({
 // hide loader whenever you want
 loader.hide();
 ```
+## Style
+```scss
+//Set loader or overlay color by overriding SCSS variables
 
+$loaderColor: #ff0000;
+$loaderBackground: #808080;
+
+@import  'vue-loading-overlay/src/scss/index.scss';
+```
 ## Install in non-module environments (without webpack)
 ```html
 <!-- Vue js -->


### PR DESCRIPTION
Add SCSS variables in the readme for updating loader or overlay color.