### PR TITLE
Rearranged possibly miss written ternary operator.

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -10,6 +10,6 @@ const hasWindow = () => {
   return typeof window !== 'undefined';
 };
 
-const HTMLElement = hasWindow() ? window.HTMLElement : Object;
+const HTMLElement = hasWindow() ? Object : window.HTMLElement;
 
 export {removeElement, hasWindow, HTMLElement}


### PR DESCRIPTION
I was using Nuxt and getting `ReferenceError: window is not defined` when rendering serverside and found `const HTMLElement = hasWindow() ? window.HTMLElement : Object;` which I believe should be the other way around.

It was such a small fix I just submitted a PR without an issue.

As far as testing, it now works on my project, but if I missed something let me know.