### PR TITLE
fix css

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,3 +1,4 @@
+/* must empty or comment */
 .vld-overlay {
   bottom: 0;
   left: 0;


### PR DESCRIPTION
First line in css file must empty or use for comment, because if it’s not, then when you use lazy loading and the webpack it breaks the styles.
```
webpackContext.id = "./node_modules/moment/locale sync recursive ^\\.\\/.*$";.vld-overlay {
  bottom: 0;
  left: 0;
  position: absolute;
  right: 0;
  top: 0;
  -webkit-box-align: center;
          align-items: center;
  display: none;
  -webkit-box-pack: center;
          justify-content: center;
  overflow: hidden;
  z-index: 1
}
```