### PR TITLE
fix(types): change augmented module to "vue"

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,7 +35,7 @@ export interface PluginApi {
   show(props?: Props, slots?: Slots): ActiveLoader
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     readonly $loading: PluginApi;
   }


### PR DESCRIPTION
According to [Vue Router](https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#441-2024-07-31) and the [Vue documentation](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties), module augmentation has to be done on the `"vue"` module instead of the `"@vue/runtime-core"` module. 

Making this change solves the typescript issues in my project and should have no impact on the functional aspect of this library.